### PR TITLE
【Fixed】合格要件を満たす賃貸物件アプリケーションの作成

### DIFF
--- a/app/assets/stylesheets/properties.scss
+++ b/app/assets/stylesheets/properties.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the properties controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,0 +1,2 @@
+class PropertiesController < ApplicationController
+end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -7,6 +7,7 @@ class PropertiesController < ApplicationController
 
   def new 
     @property = Property.new
+    2.times { @property.stations.build }
     render :index and return if params[:back]
   end
 
@@ -20,11 +21,10 @@ class PropertiesController < ApplicationController
   end
 
   def show 
-    
   end
 
   def edit
-
+    @property.stations.index_by+1.times { @property.stations.build }
   end
 
   def update
@@ -43,7 +43,7 @@ class PropertiesController < ApplicationController
   private 
 
   def property_params
-    params.require(:property).permit(%i[name price address age remarks])
+    params.require(:property).permit(:name, :price, :address, :age, :remarks, stations_attributes: [:id, :train_name, :station_name, :walk_minutes, :_destroy])
   end
 
   def set_property

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,2 +1,43 @@
 class PropertiesController < ApplicationController
+  
+  def index 
+    @properties = Property.all.order("id DESC")
+  end
+
+  def new 
+    @property = Property.new
+    render :index and return if params[:back]
+  end
+
+  def create 
+    @property = Property.build(property_params)
+    if @property.save
+      redirect_to properties_path, notice: "物件情報を登録しました！"
+    else
+      render :new
+    end
+  end
+
+  def show 
+
+  end
+
+  def edit
+
+  end
+
+  def update
+
+  end
+
+  def destroy 
+
+  end
+
+  private 
+
+  def property_params
+    params.require(:property).permit(%i[name price address age remarks])
+  end
+
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -28,11 +28,14 @@ class PropertiesController < ApplicationController
   end
 
   def update
-
+    if @property.update(property_params)
+      redirect_to properties_path, notice: "物件の情報を更新しました！"
+    else
+      render :edit
+    end
   end
 
   def destroy 
-
   end
 
   private 

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -29,13 +29,15 @@ class PropertiesController < ApplicationController
 
   def update
     if @property.update(property_params)
-      redirect_to properties_path, notice: "物件の情報を更新しました！"
+      redirect_to properties_path, notice: "物件情報を更新しました！"
     else
       render :edit
     end
   end
 
   def destroy 
+    @property.destroy
+    redirect_to properties_path, notice: "物件情報を削除しました！"
   end
 
   private 

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,4 +1,5 @@
 class PropertiesController < ApplicationController
+  before_action :set_property, only: %i[show edit update destroy]
   
   def index 
     @properties = Property.all.order("id DESC")
@@ -10,7 +11,7 @@ class PropertiesController < ApplicationController
   end
 
   def create 
-    @property = Property.build(property_params)
+    @property = Property.new(property_params)
     if @property.save
       redirect_to properties_path, notice: "物件情報を登録しました！"
     else
@@ -19,7 +20,7 @@ class PropertiesController < ApplicationController
   end
 
   def show 
-
+    
   end
 
   def edit
@@ -40,4 +41,7 @@ class PropertiesController < ApplicationController
     params.require(:property).permit(%i[name price address age remarks])
   end
 
+  def set_property
+    @property = Property.find(params[:id])
+  end
 end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -1,0 +1,2 @@
+module PropertiesHelper
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,0 +1,2 @@
+class Property < ApplicationRecord
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,4 +1,5 @@
 class Property < ApplicationRecord
-  has_many :stations
+  has_many :stations, dependent: :destroy
+  accepts_nested_attributes_for :stations, allow_destroy: true, reject_if: lambda {|attributes| attributes['train_name'].blank?}
 end
 

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,2 +1,4 @@
 class Property < ApplicationRecord
+  has_many :stations
 end
+

--- a/app/models/station.rb
+++ b/app/models/station.rb
@@ -1,0 +1,3 @@
+class Station < ApplicationRecord
+  belongs_to :property
+end

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(mode: @property, local: true) do |f| %>
+  <div>
+    <%= f.label "物件名" %><br>
+    <%= f.text_field :name %><br>
+    <%= f.label "賃料" %><br>
+    <%= f.text_field :price %>円<br>
+    <%= f.label "住所" %><br>
+    <%= f.text_field :address %><br>
+    <%= f.label "築年数" %><br>
+    <%= f.text_field :age %>年<br>
+    <%= f.label "備考" %><br>
+    <%= f.text_area :remarks %><br>
+  </div>
+
+  <%= f.submit "登録する" %>
+<% end %>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -12,5 +12,19 @@
     <%= f.text_area :remarks %><br>
   </div>
 
+  <hr>
+
+  <%= f.fields_for :stations do |stations_f| %>     
+    <div>
+      <h2>最寄り駅 <%= stations_f.index+1 %></h2>
+        <%= stations_f.label "路線名" %><br>
+        <%= stations_f.text_field :train_name %><br>
+        <%= stations_f.label "駅名" %><br>
+        <%= stations_f.text_field :station_name %><br>
+        <%= stations_f.label "徒歩分数" %><br>
+        <%= stations_f.text_field :walk_minutes %>分<br>
+    </div>
+  <% end %>  
+
   <%= f.submit "登録する" %>
 <% end %>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(mode: @property, local: true) do |f| %>
+<%= form_with(model: @property, local: true) do |f| %>
   <div>
     <%= f.label "物件名" %><br>
     <%= f.text_field :name %><br>

--- a/app/views/properties/edit.html.erb
+++ b/app/views/properties/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>物件編集</h1>
+
+<%= render 'form', property: @property %>
+
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -1,0 +1,11 @@
+<h1>物件一覧</h1>
+
+<table>
+  <tr>
+    <th>物件名</th>
+    <th>賃料</th>
+    <th>住所</th>
+    <th>築年数</th>
+    <th>備考</th>
+  </tr>
+</table>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -1,5 +1,7 @@
 <h1>物件一覧</h1>
 
+<p id="notice"><%= notice %></p>
+
 <table>
   <tr>
     <th>物件名</th>
@@ -8,4 +10,19 @@
     <th>築年数</th>
     <th>備考</th>
   </tr>
+
+  <% @properties.each do |property| %>
+    <tr>
+      <td><%= property.name %></td>
+      <td><%= property.price %></td>
+      <td><%= property.address %></td>
+      <td><%= property.age %></td>
+      <td><%= property.remarks %></td>
+      <td><%= link_to "詳細", property_path  %></td>
+      <td><%= link_to "編集", edit_property_path %></td>
+      <td><%= link_to "削除", property, method: :delete, date: {confirm: '本当に削除していいですか？'}  %></td>
+    </tr>
+  <% end %>
 </table>
+
+<%= link_to "物件を登録する", new_property_path %>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -14,13 +14,13 @@
   <% @properties.each do |property| %>
     <tr>
       <td><%= property.name %></td>
-      <td><%= property.price %></td>
+      <td><%= property.price %>円</td>
       <td><%= property.address %></td>
-      <td><%= property.age %></td>
+      <td><%= property.age %>年</td>
       <td><%= property.remarks %></td>
-      <td><%= link_to "詳細", property_path  %></td>
-      <td><%= link_to "編集", edit_property_path %></td>
-      <td><%= link_to "削除", property, method: :delete, date: {confirm: '本当に削除していいですか？'}  %></td>
+      <td><%= link_to "詳細", property_path(property.id) %></td>
+      <td><%= link_to "編集", edit_property_path(property.id) %></td>
+      <td><%= link_to "削除", property_path(property.id), method: :delete, data: {confirm: '本当に削除していいですか？'}  %></td>
     </tr>
   <% end %>
 </table>

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,0 +1,5 @@
+<h1>物件登録</h1>
+
+<%= render 'form', property: @property %>
+
+<%= link_to '戻る', properties_path, name: :back %>

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,5 +1,5 @@
 <h1>物件登録</h1>
 
-<%= render 'form', property: @property %>
+<%= render 'form', property: @property %><br>
 
 <%= link_to '戻る', properties_path, name: :back %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -1,0 +1,8 @@
+<p>物件名： <%= @property.name %></p>
+<p>賃料： <%= @property.price %>円</p>
+<p>住所： <%= @property.address %></p>
+<p>築年数： <%= @property.age %>年</p>
+<p>備考： <%= @property.remarks %></p>
+
+<%= link_to "編集", edit_property_path %> |
+<%= link_to "戻る", properties_path, name: :back %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -1,8 +1,23 @@
-<p>物件名： <%= @property.name %></p>
-<p>賃料： <%= @property.price %>円</p>
-<p>住所： <%= @property.address %></p>
-<p>築年数： <%= @property.age %>年</p>
-<p>備考： <%= @property.remarks %></p>
+<div>
+  <p>物件名：<%= @property.name %></p>
+  <p>賃料：<%= @property.price %>円</p>
+  <p>住所：<%= @property.address %></p>
+  <p>築年数：<%= @property.age %>年</p>
+  <p>備考：<%= @property.remarks %></p>
+</div>
+
+<hr>
+
+<div>
+  <% @property.stations.each_with_index do |value, index| %>
+    <tr>
+      <h3>最寄り駅 <%= "#{index+1}" %></h3>
+      <p>路線名：<%= value.train_name %></p>
+      <p>駅名：<%= value.station_name %></p>
+      <p>徒歩分数：<%= value.walk_minutes %>分</p>
+    </tr>
+  <% end %>
+</div>
 
 <%= link_to "編集", edit_property_path %> |
 <%= link_to "戻る", properties_path, name: :back %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,3 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  resources :properties
 end

--- a/db/migrate/20220624170240_create_properties.rb
+++ b/db/migrate/20220624170240_create_properties.rb
@@ -1,0 +1,13 @@
+class CreateProperties < ActiveRecord::Migration[6.0]
+  def change
+    create_table :properties do |t|
+      t.text :name
+      t.text :price
+      t.text :address
+      t.text :age
+      t.string :remarks
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220624184015_create_stations.rb
+++ b/db/migrate/20220624184015_create_stations.rb
@@ -1,0 +1,11 @@
+class CreateStations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :stations do |t|
+      t.text :train_name 
+      t.text :station_name
+      t.text :walk_minutes
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220624185535_add_property_ref_to_stations.rb
+++ b/db/migrate/20220624185535_add_property_ref_to_stations.rb
@@ -1,0 +1,5 @@
+class AddPropertyRefToStations < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :stations, :property, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2022_06_24_170240) do
+
+  create_table "properties", force: :cascade do |t|
+    t.text "name"
+    t.text "price"
+    t.text "address"
+    t.text "age"
+    t.string "remarks"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_24_170240) do
+ActiveRecord::Schema.define(version: 2022_06_24_185535) do
 
   create_table "properties", force: :cascade do |t|
     t.text "name"
@@ -22,4 +22,15 @@ ActiveRecord::Schema.define(version: 2022_06_24_170240) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "stations", force: :cascade do |t|
+    t.text "train_name"
+    t.text "station_name"
+    t.text "walk_minutes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.integer "property_id", null: false
+    t.index ["property_id"], name: "index_stations_on_property_id"
+  end
+
+  add_foreign_key "stations", "properties"
 end

--- a/test/controllers/properties_controller_test.rb
+++ b/test/controllers/properties_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PropertiesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/properties.yml
+++ b/test/fixtures/properties.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/stations.yml
+++ b/test/fixtures/stations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/property_test.rb
+++ b/test/models/property_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PropertyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/station_test.rb
+++ b/test/models/station_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class StationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・最寄駅がゼロの場合、もしくは1つしかない物件も登録できること
・賃貸物件の新規登録画面・詳細画面において追加した最寄り駅の数が表示されていること
・編集画面では、あらたにひとつの最寄駅を登録できる入力欄を表示させること。最寄駅の登録数が増えても対応できるようにすること。